### PR TITLE
docs: SQD rebrand + canonical doc links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,16 @@
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/subsquid/squid-abi-template)
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/subsquid-labs/squid-abi-template)
 
-# Squid ABI template
+# EVM ABI indexer template (Squid SDK)
 
 An experimental template is used to generate a squid that indexes EVM logs and transactions of choice from a contract address. Supports automatic ABI lookups for public contracts using the Etherscan API
 
+## Documentation
+
+See [docs.sqd.dev](https://docs.sqd.dev) and [sqd.dev](https://sqd.dev).
+
 ## Usage
 
-0. Install the [Squid CLI](https://docs.subsquid.io/squid-cli/):
+0. Install the [Squid CLI](https://docs.sqd.dev/en/squid-cli):
 
 ```sh
 npm i -g @subsquid/cli
@@ -15,7 +19,7 @@ npm i -g @subsquid/cli
 1. Init the template and install the dependencies
 
 ```bash
-sqd init my-abi-squid --template https://github.com/subsquid/squid-abi-template
+sqd init my-abi-squid --template https://github.com/subsquid-labs/squid-abi-template
 cd my-abi-squid
 npm i
 ```
@@ -52,7 +56,7 @@ sqd serve
 
 4. Inspect `schema.graphql`, `src/processor.ts` and start hacking!
 
-For more details on how to build and deploy a squid, see the [docs](https://docs.subsquid.io).
+For more details on how to build and deploy a squid, see the [docs](https://docs.sqd.dev).
 
 ## Example
 ### Generate


### PR DESCRIPTION
SEO cleanup: repoint legacy docs.subsquid.io/subsquid.io links to verified docs.sqd.dev/sqd.dev URLs, rebrand Subsquid -> SQD, bump Node prerequisite, fix template/Gitpod paths to the subsquid-labs org. Every link verified 200.